### PR TITLE
fix(docs-site): strip frontmatter on Windows CRLF line endings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Tous les changements notables de BASE sont documentés ici. Le format suit l'esp
 
 BASE suit le [Semantic Versioning](https://semver.org/lang/fr/): la surface publique stable (format des ressources, commandes CLI, outils MCP, schémas de projection, contrat des points d'extension) ne casse pas sans incrément majeur. Détail: [Versions et stabilité](docs/reference/versions-et-stabilite.md).
 
+## [Unreleased]
+
+### Corrigé
+- **base-docs-site**: le frontmatter YAML s'affichait en clair dans le corps des pages sur Windows. `stripFrontmatter()` testait `startsWith("---\n")` sans tenir compte des fins de ligne CRLF (`\r\n`). Corrigé en acceptant les deux, et en splittant sur `/\r?\n/` pour éviter les `\r` parasites dans le contenu rendu. (Fixes #10)
+
 ## [1.0.0] - 2026-06-25
 
 Première version publique de BASE: un cadre **local-first** et **ouvert** pour structurer la collaboration humain-IA. Le savoir métier vit dans des fichiers Markdown que vous possédez; un cœur **sans dépendance tierce** (Node 18 ou plus) médie les actions sensibles; et tout ce qui sort vers un outil tiers reste un **choix explicite**. La promesse tient en une ligne: l'IA travaille à partir de ce que vous avez structuré plutôt que de suppositions, et vous gardez la main sur ce qu'elle voit, ce qu'il faut vérifier et où elle s'arrête.

--- a/packages/base-docs-site/src/lib/model.ts
+++ b/packages/base-docs-site/src/lib/model.ts
@@ -196,8 +196,8 @@ function escapeAttribute(value: string): string {
 }
 
 function stripFrontmatter(content: string): string {
-  if (!content.startsWith("---\n")) return content;
-  const lines = content.split("\n");
+  if (!content.startsWith("---\n") && !content.startsWith("---\r\n")) return content;
+  const lines = content.split(/\r?\n/);
   const end = lines.findIndex((line, index) => index > 0 && line.trim() === "---");
   return end === -1 ? content : lines.slice(end + 1).join("\n");
 }


### PR DESCRIPTION
stripFrontmatter() tested startsWith('---\n') without accounting for Windows CRLF line endings. Fixed by accepting both LF and CRLF, and splitting on /\r?\n/ to avoid stray \r characters in the rendered body.

Fixes #10
[SPEC-NEUTRAL: docs-site rendering fix, no BASE spec behaviour changed]

## Summary

<!-- What changes, and why. Link any related issue. -->

## Type

- [ ] Fix
- [ ] Feature
- [ ] Docs
- [ ] Refactor / tests / tooling

## Checklist

- [ ] `npm test` green (core + packages)
- [ ] `npm run typecheck` clean
- [ ] `node tools/base.mjs validate --root .` → "BASE valide."
- [ ] `node tools/base.mjs route-test --root .` stable (and the example fixtures, if routing changed)
- [ ] Derived artifacts regenerated if needed (`npm run index`, `base build --write`)
- [ ] MCP touched? `cd mcp && npm run build && npm test` (the build runs `tsc`; vitest alone does not type-check)
- [ ] Studio touched? `cd tools/studio/ui && npm test && npm run build` (and `npm run e2e` for user flows)
- [ ] No em-dashes in French public content; specs/docs updated if behaviour changed
- [ ] A test accompanies any change to verifiable behaviour

<!-- See CONTRIBUTING.md and specs/TESTING.md for the full baseline. -->
