### PR TITLE
fix(frontmatter): accept CRLF line endings on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Tous les changements notables de BASE sont documentés ici. Le format suit l'esp
 
 BASE suit le [Semantic Versioning](https://semver.org/lang/fr/): la surface publique stable (format des ressources, commandes CLI, outils MCP, schémas de projection, contrat des points d'extension) ne casse pas sans incrément majeur. Détail: [Versions et stabilité](docs/reference/versions-et-stabilite.md).
 
+## [Unreleased]
+
+### Corrigé
+- **frontmatter**: `parseFrontmatter()` retournait `data: {}` et laissait le frontmatter dans le corps sur les fichiers à fins de ligne CRLF (Windows). Le test d'entrée `startsWith("---\n")` et le `split("\n")` ne tenaient pas compte du `\r`. Corrigé en acceptant `\r\n` et en splittant sur `/\r?\n/`; Studio affiche désormais les métadonnées correctement sur Windows.
+
 ## [1.0.0] - 2026-06-25
 
 Première version publique de BASE: un cadre **local-first** et **ouvert** pour structurer la collaboration humain-IA. Le savoir métier vit dans des fichiers Markdown que vous possédez; un cœur **sans dépendance tierce** (Node 18 ou plus) médie les actions sensibles; et tout ce qui sort vers un outil tiers reste un **choix explicite**. La promesse tient en une ligne: l'IA travaille à partir de ce que vous avez structuré plutôt que de suppositions, et vous gardez la main sur ce qu'elle voit, ce qu'il faut vérifier et où elle s'arrête.

--- a/tests/base-frontmatter.test.mjs
+++ b/tests/base-frontmatter.test.mjs
@@ -197,3 +197,17 @@ describe("parseScalar", () => {
     assert.equal(parseScalar('"keep # inside"'), "keep # inside");
   });
 });
+
+describe("frontmatter — CRLF line endings (Windows)", () => {
+  it("parses a file with CRLF line endings identically to LF", () => {
+    const lf = "---\nid: demo\ntype: agent\ntitle: Demo\ndescription: D.\n---\nbody text\n";
+    const crlf = lf.replace(/\n/g, "\r\n");
+    const rLf = parseFrontmatter(lf);
+    const rCrlf = parseFrontmatter(crlf);
+    assert.deepEqual(rCrlf.errors, [], "CRLF file must not produce parse errors");
+    assert.equal(rCrlf.data.id, "demo");
+    assert.equal(rCrlf.data.type, "agent");
+    assert.equal(rCrlf.data.title, "Demo");
+    assert.equal(rCrlf.body.trim(), rLf.body.trim(), "body must match LF version");
+  });
+});

--- a/tools/core/frontmatter.mjs
+++ b/tools/core/frontmatter.mjs
@@ -23,11 +23,11 @@ function makeError(line, code, detail) {
 }
 
 export function parseFrontmatter(content) {
-  if (!content.startsWith(FRONTMATTER_DELIMITER + "\n")) {
+  if (!content.startsWith(FRONTMATTER_DELIMITER + "\n") && !content.startsWith(FRONTMATTER_DELIMITER + "\r\n")) {
     return { data: {}, raw: "", body: content, errors: [] };
   }
 
-  const allLines = content.split("\n");
+  const allLines = content.split(/\r?\n/);
   const end = allLines.findIndex((line, index) => index > 0 && line.trim() === FRONTMATTER_DELIMITER);
   if (end === -1) {
     return {


### PR DESCRIPTION
Sur Windows, `parseFrontmatter()` retournait `data: {}` et laissait le bloc frontmatter visible dans le corps de la ressource. Studio affichait les métadonnées vides et le YAML en clair.

Deux causes dans `tools/core/frontmatter.mjs` :
- `startsWith(FRONTMATTER_DELIMITER + "\n")` ratait le `\r` avant le `\n`
- `content.split("\n")` laissait un `\r` en fin de chaque ligne, cassant le parsing clé/valeur

Corrigé en acceptant `\r\n` sur le test d'entrée et en splittant sur `/\r?\n/`. Même pattern que le fix #10 (`stripFrontmatter` dans la docs-site), source différente.

Test ajouté : `"parses a file with CRLF line endings identically to LF"` — rouge avant, vert après.

Fixes #15
[SPEC-NEUTRAL: no routing or write-gate behaviour changed]
