### PR TITLE
docs(github): DCO et branche mono-sujet en tête de la checklist de PR

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,6 +11,8 @@
 
 ## Checklist
 
+- [ ] Every commit is signed off (`git commit -s`; the DCO check rejects unsigned commits, `git rebase --signoff` repairs a branch)
+- [ ] The branch starts from an up-to-date `main` and carries this one topic only
 - [ ] `npm test` green (core + packages)
 - [ ] `npm run typecheck` clean
 - [ ] `node tools/base.mjs validate --root .` → "BASE valide."


### PR DESCRIPTION
La checklist du template de PR commence désormais par les deux points qui bloquent le plus souvent une contribution: la signature DCO de chaque commit et la branche mono-sujet partie d'un `main` à jour. CONTRIBUTING.md les documentait déjà; le template les rappelle au moment où l'on ouvre la PR.
